### PR TITLE
Reference to Tracks Addon only if available

### DIFF
--- a/install.php
+++ b/install.php
@@ -44,7 +44,7 @@ if (rex_config::get('warehouse', 'order_email') == '') {
     rex_config::set('order_email', rex::getErrorEmail());
 }
 
-if (rex_config::get('warehouse', 'editor') == '' && rex_addon::get('tracks')->isAvailable()) {
+if (rex_config::get('warehouse', 'editor') == '' && rex_addon::get('tracks')?->isAvailable()) {
     $class = Alexplusde\Tracks\Editor::getFirstEditorProfile();
     rex_config::set('warehouse', 'editor', $class);
 }

--- a/install.php
+++ b/install.php
@@ -1,7 +1,5 @@
 <?php
 
-use Alexplusde\Tracks\Editor;
-
 // Überprüfe aktuell installierte Version von Warehouse
 /*
 if (rex_version::compare($this->getVersion(), '2.0.0', '<')) {
@@ -46,8 +44,8 @@ if (rex_config::get('warehouse', 'order_email') == '') {
     rex_config::set('order_email', rex::getErrorEmail());
 }
 
-if (rex_config::get('warehouse', 'editor') == '') {
-    $class = Editor::getFirstEditorProfile();
+if (rex_config::get('warehouse', 'editor') == '' && rex_addon::get('tracks')->isAvailable()) {
+    $class = Alexplusde\Tracks\Editor::getFirstEditorProfile();
     rex_config::set('warehouse', 'editor', $class);
 }
 


### PR DESCRIPTION
closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by ensuring the 'editor' configuration is set only when the required addon is available, preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->